### PR TITLE
Fix event rescheduling bug when actor is present.

### DIFF
--- a/lib/reactor/version.rb
+++ b/lib/reactor/version.rb
@@ -1,3 +1,3 @@
 module Reactor
-  VERSION = "0.9.2"
+  VERSION = "0.9.3"
 end


### PR DESCRIPTION
If two events of the same name had the same scheduled time, it would arbitrarily delete the first irrespective of actor.
Added a spec to verify that behavior is expected when an actor is passed.
Fixed a couple typos.
Updated version to 0.9.3.