### PR TITLE
Fix error caused by non-Reactor Sidekiq jobs

### DIFF
--- a/lib/reactor/event.rb
+++ b/lib/reactor/event.rb
@@ -66,23 +66,18 @@ class Reactor::Event
     def reschedule(name, data = {})
       scheduled_jobs = Sidekiq::ScheduledSet.new
       job = scheduled_jobs.detect do |job|
-        same_class = job['class'] == self.name.to_s
-        same_name = job['args'].first == name.to_s
-        same_at = job.score.to_i == data[:was].to_i
+        return false if job['class'] != self.name.to_s
+
+        same_event_name  = job['args'].first == name.to_s
+        same_at_time     = job.score.to_i == data[:was].to_i
 
         if data[:actor]
-          job_data = job['args'].second
+          same_actor =  job['args'].second['actor_type']  == data[:actor].class.name &&
+                        job['args'].second['actor_id']    == data[:actor].id
 
-          if job_data
-            same_actor =  job_data['actor_type'] == data[:actor].class.name &&
-                          job_data['actor_id'] == data[:actor].id
-          else
-            same_actor = false
-          end
-
-          same_class && same_name && same_at && same_actor
+          same_event_name && same_at_time && same_actor
         else
-          same_class && same_name && same_at
+          same_event_name && same_at_time
         end
       end
 

--- a/lib/reactor/version.rb
+++ b/lib/reactor/version.rb
@@ -1,3 +1,3 @@
 module Reactor
-  VERSION = "0.9.4"
+  VERSION = "0.9.5"
 end


### PR DESCRIPTION
The reschedule method was checking for further parameters after determining the class of the job was different.
This seems to have been raising exceptions when searching through jobs that were not Reactor::Events.
Reorganized the reschedule method for increased clarity.
Bump to version 0.9.5.