### PR TITLE
Update for ActiveRecord 4.2

### DIFF
--- a/lib/reactor.rb
+++ b/lib/reactor.rb
@@ -46,5 +46,10 @@ module Reactor
   end
 end
 
+# Temporarily avoid Rails 4.2.0 deprecation warning
+if ActiveRecord::VERSION::STRING > '4.2'
+  ActiveRecord::Base.raise_in_transactional_callbacks = true
+end
+
 ActiveRecord::Base.send(:include, Reactor::Publishable)
 ActiveRecord::Base.send(:include, Reactor::Subscribable)

--- a/lib/reactor/models/concerns/subscribable.rb
+++ b/lib/reactor/models/concerns/subscribable.rb
@@ -28,7 +28,9 @@ module Reactor::Subscribable
           return :__perform_aborted__ if dont_perform && !Reactor::TEST_MODE_SUBSCRIBERS.include?(source)
           event = Reactor::Event.new(data)
           if method.is_a?(Symbol)
-            source.delay_for(delay).send(method, event)
+            ActiveSupport::Deprecation.silence do
+              source.delay_for(delay).send(method, event)
+            end
           else
             method.call(event)
           end

--- a/lib/reactor/version.rb
+++ b/lib/reactor/version.rb
@@ -1,3 +1,3 @@
 module Reactor
-  VERSION = "0.9.6"
+  VERSION = "0.9.7"
 end

--- a/reactor.gemspec
+++ b/reactor.gemspec
@@ -18,10 +18,10 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "sidekiq", "< 4.0"
-  spec.add_dependency 'activerecord', '< 4.2'
+  spec.add_dependency "sidekiq", '< 4.0'
+  spec.add_dependency 'activerecord', '< 5.0'
 
-  spec.add_development_dependency "bundler", "~> 1.3"
+  spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec", "~> 3.0.0"
   spec.add_development_dependency "rspec-its"

--- a/spec/models/concerns/subscribable_spec.rb
+++ b/spec/models/concerns/subscribable_spec.rb
@@ -35,7 +35,7 @@ describe Reactor::Subscribable do
   describe 'on_event' do
     it 'binds block of code statically to event being fired' do
       expect_any_instance_of(Auction).to receive(:update_column).with(:status, 'first_bid_made')
-      Reactor::Event.publish(:bid_made, target: Auction.create)
+      Reactor::Event.publish(:bid_made, target: Auction.create!(start_at: 10.minutes.from_now))
     end
 
     describe 'building uniquely named subscriber handler classes' do
@@ -65,7 +65,7 @@ describe Reactor::Subscribable do
 
     it 'accepts wildcard event name' do
       expect_any_instance_of(Auction).to receive(:more_puppies!)
-      Reactor::Event.publish(:another_event, actor: Auction.create)
+      Reactor::Event.publish(:another_event, actor: Auction.create!(start_at: 5.minutes.from_now))
     end
 
     describe 'in_memory flag' do

--- a/spec/support/active_record.rb
+++ b/spec/support/active_record.rb
@@ -11,14 +11,14 @@ ActiveRecord::Migration.create_table :auctions do |t|
   t.boolean :we_want_it
   t.integer :pet_id
 
-  t.timestamps
+  t.timestamps null: false
 end
 
 ActiveRecord::Migration.create_table :subscribers do |t|
   t.string :event_name
   t.string :type
 
-  t.timestamps
+  t.timestamps null: false
 end
 
 ActiveRecord::Migration.create_table :pets do |t|
@@ -26,13 +26,13 @@ ActiveRecord::Migration.create_table :pets do |t|
   t.string :type
 
 
-  t.timestamps
+  t.timestamps null: false
 end
 
 ActiveRecord::Migration.create_table :arbitrary_models do |t|
   t.integer :awesomeness
 
-  t.timestamps
+  t.timestamps null: false
 end
 
 class Pet < ActiveRecord::Base


### PR DESCRIPTION
Set new AR gemspec limit to 4.3.
Set "null: false" on timestamps to avoid deprecation warnings.
Set raise_in_transactional_callbacks to true to avoid deprecation warnings.
Fix apparent bug in subscribable_spec wherein start_at was causing an exception due to being null.
Bump version to 0.9.7.
Suppress `delay` deprecation warning on ActionMailer as it is being removed in a future Sidekiq version.
(mperham/sidekiq#2186)
[#81515520]