### PR TITLE
Allow the use of `data` as a key for events

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,5 +1,12 @@
 # Reactor Change Log
 
+0.12.0
+-----------
+Use `__data__` as the internal data hash. THIS _MAY BE_ A BREAKING CHANGE.
+
+If someone wants to use the key `data` for their event attributes, it would get confused with the internal event data. The internal event data is now called `__data__`. 
+Some users of this library access event.data directly. This is a breaking change for them.
+
 0.11.4
 -----------
 Fixes an issue related to class reloading in Rails development and test modes

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    reactor (0.11.4)
+    reactor (0.12.0)
       activerecord (< 5.0)
       sidekiq
 

--- a/lib/reactor/version.rb
+++ b/lib/reactor/version.rb
@@ -1,3 +1,3 @@
 module Reactor
-  VERSION = "0.11.4"
+  VERSION = "0.12.0"
 end


### PR DESCRIPTION
Preserves previous function of being able to do `event.data` to get all the
data. Exception: If your event data contains the key `data`, you can't get all
the data that way. caveat emptor.

Fixes Issue #41 

Reviewer, please examine carefully as it's my first time with Reactor.