### PR TITLE
generate subscriber worker classes with more deterministic names

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,0 +1,13 @@
+# Reactor Change Log
+
+0.11.0
+-----------
+Static Subscriber class names have changed to be more deterministic. THIS _MAY BE_ A BREAKING CHANGE.
+See https://github.com/hired/reactor/issues/40 for background info.
+
+Previously, when you added an `on_event :foo` block to an object, say `MyObject`, Reactor would dynamically generate a Sidekiq worker class named `Reactor::StaticSubscribers::FooHandler0`.
+
+In 0.11.0, the naming of this dynamically generated worker class has changed to `Reactor::StaticSubscribers::MyObject::FooHandler`.
+If you require more than one `on_event` block for the same event, you must name the handler so that it is unique and deterministic: i.e. `on_event :foo, handler_name: :do_better` otherwise an exception will be raised at load time.
+
+Because the worker class names are changing, when deploying this change it's important that your Sidekiq queue not have any pending jobs with the old naming scheme, otherwise they will fail to deserialize!

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    reactor (0.10.1)
+    reactor (0.11.0)
       activerecord (< 5.0)
       sidekiq
 

--- a/lib/reactor/models/concerns/subscribable.rb
+++ b/lib/reactor/models/concerns/subscribable.rb
@@ -7,23 +7,32 @@ module Reactor::Subscribable
     def on_event(*args, &block)
       options = args.extract_options!
       event, method = args
-      (Reactor::SUBSCRIBERS[event.to_s] ||= []).push(StaticSubscriberFactory.create(event, method, {source: self}.merge(options), &block))
+      (Reactor::SUBSCRIBERS[event.to_s] ||= []).push(create_static_subscriber(event, method, options, &block))
     end
-  end
 
-  class StaticSubscriberFactory
+    private
 
-    def self.create(event, method = nil, options = {}, &block)
-      source_class          = options[:source] ? options[:source].name : 'Anonymous'
+    def create_static_subscriber(event, method = nil, options = {}, &block)
+      worker_class = build_worker_class
 
-      handler_name = if options[:handler_name]
-        options[:handler_name].to_s.camelize
-      else
-        handler_class_prefix = event == '*' ? 'Wildcard': event.to_s.camelize
-        "#{handler_class_prefix}Handler"
+      name_worker_class worker_class, handler_name(event, options[:handler_name])
+
+      worker_class.tap do |k|
+        k.source = self
+        k.method = method || block
+        k.delay = options[:delay] || 0
+        k.in_memory = options[:in_memory]
+        k.dont_perform = Reactor.test_mode?
       end
+    end
 
-      klass = Class.new do
+    def handler_name(event, handler_name_option = nil)
+      return handler_name_option.to_s.camelize if handler_name_option
+      "#{event == '*' ? 'Wildcard': event.to_s.camelize}Handler"
+    end
+
+    def build_worker_class
+      Class.new do
         include Sidekiq::Worker
 
         class_attribute :method, :delay, :source, :in_memory, :dont_perform
@@ -46,30 +55,24 @@ module Reactor::Subscribable
           end
         end
       end
+    end
 
-      # dynamically define a module namespace based on the subscriber's class name
-      unless Reactor::StaticSubscribers.const_defined?(source_class, false)
-        Reactor::StaticSubscribers.const_set(source_class, Module.new)
+    def name_worker_class(klass, handler_name)
+      if static_subscriber_namespace.const_defined?(handler_name)
+        raise EventHandlerAlreadyDefined.new(
+          "A Reactor event named #{handler_name} already has been defined on #{static_subscriber_namespace}.
+           Specify a `:handler_name` option on your subscriber's `on_event` declaration to name this event handler deterministically."
+        )
+      end
+      static_subscriber_namespace.const_set(handler_name, klass)
+    end
+
+    def static_subscriber_namespace
+      unless Reactor::StaticSubscribers.const_defined?(self.name, false)
+        Reactor::StaticSubscribers.const_set(self.name, Module.new)
       end
 
-      namespace = Reactor::StaticSubscribers.const_get(source_class, false)
-
-      if namespace.const_defined?(handler_name)
-        raise EventHandlerAlreadyDefined.new %{ A Reactor event named #{handler_name} already has been defined on #{namespace}.
-            Specify a `:handler_name` option on your subscriber's `on_event` declaration to name this event handler deterministically.
-          }
-      end
-
-      # add the event handler class to the namespace
-      namespace.const_set(handler_name, klass)
-
-      klass.tap do |k|
-        k.method = method || block
-        k.delay = options[:delay] || 0
-        k.source = options[:source]
-        k.in_memory = options[:in_memory]
-        k.dont_perform = Reactor.test_mode?
-      end
+      Reactor::StaticSubscribers.const_get(self.name, false)
     end
   end
 end

--- a/lib/reactor/version.rb
+++ b/lib/reactor/version.rb
@@ -1,3 +1,3 @@
 module Reactor
-  VERSION = "1.0.0"
+  VERSION = "0.11.0"
 end

--- a/lib/reactor/version.rb
+++ b/lib/reactor/version.rb
@@ -1,3 +1,3 @@
 module Reactor
-  VERSION = "0.10.1"
+  VERSION = "1.0.0"
 end

--- a/spec/event_spec.rb
+++ b/spec/event_spec.rb
@@ -60,10 +60,10 @@ describe Reactor::Event do
 
       before do
         Reactor::SUBSCRIBERS['barfed'] ||= []
-        Reactor::SUBSCRIBERS['barfed'] << Reactor::Subscribable::StaticSubscriberFactory.create('barfed') do |event|
+        Reactor::SUBSCRIBERS['barfed'] << Reactor::Subscribable::StaticSubscriberFactory.create('barfed', nil, handler_name: 'bad') do |event|
           raise 'UNEXPECTED!'
         end
-        Reactor::SUBSCRIBERS['barfed'] << Reactor::Subscribable::StaticSubscriberFactory.create('barfed') do |event|
+        Reactor::SUBSCRIBERS['barfed'] << Reactor::Subscribable::StaticSubscriberFactory.create('barfed', nil, handler_name: 'good') do |event|
           mock.some_method
         end
       end

--- a/spec/event_spec.rb
+++ b/spec/event_spec.rb
@@ -9,6 +9,15 @@ module MyModule
 end
 
 class ArbitraryModel < ActiveRecord::Base
+
+  on_event :barfed, handler_name: :bad do
+    raise 'UNEXPECTED!'
+  end
+
+  on_event :barfed do
+    'that was gross'
+  end
+
 end
 
 class OtherWorker
@@ -55,18 +64,7 @@ describe Reactor::Event do
     end
 
     describe 'when subscriber throws exception', :sidekiq do
-      let(:mock) { double(:thing, some_method: 3) }
       let(:barfing_event) { Reactor::Event.perform('barfed', somethin: 'up', actor_id: model.id.to_s, actor_type: model.class.to_s) }
-
-      before do
-        Reactor::SUBSCRIBERS['barfed'] ||= []
-        Reactor::SUBSCRIBERS['barfed'] << Reactor::Subscribable::StaticSubscriberFactory.create('barfed', nil, handler_name: 'bad') do |event|
-          raise 'UNEXPECTED!'
-        end
-        Reactor::SUBSCRIBERS['barfed'] << Reactor::Subscribable::StaticSubscriberFactory.create('barfed', nil, handler_name: 'good') do |event|
-          mock.some_method
-        end
-      end
 
       it 'doesnt matter because it runs in a separate worker process' do
         expect { barfing_event }.to_not raise_exception

--- a/spec/reactor_spec.rb
+++ b/spec/reactor_spec.rb
@@ -1,14 +1,14 @@
 require 'spec_helper'
 
+Reactor.in_test_mode do
+  class SomeClass
+    include Reactor::Subscribable
+    on_event :test_event, -> (event) { self.spy_on_me }
+  end
+end
 
 describe Reactor do
-  let(:subscriber) do
-    Reactor.in_test_mode do
-      Class.new(ActiveRecord::Base) do
-        on_event :test_event, -> (event) { self.spy_on_me }
-      end
-    end
-  end
+  let(:subscriber) { SomeClass }
 
   describe '.test_mode!' do
     it 'sets Reactor into test mode' do


### PR DESCRIPTION
_instead of_ `Reactor::StaticSubscribers::EventNameHandler` now the dynamically generated class would be namespaced with the containing class name: `Reactor::StaticSubscribers::MySubscriberClass::EventNameHandler`

In the case of more than one event handler named exactly the same, an exception will be raised at load time. Developers should pass a `:handler_name` option on the event handler declaration to disambiguate.

This is a breaking change ... so Reactor 1.0?

bot review me @wnadeau 
cc @dougbarth 

[fixes #115182193]