### PR TITLE
detect subscriber naming collisions intelligently to avoid class reloading issues

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,5 +1,9 @@
 # Reactor Change Log
 
+0.11.4
+-----------
+Fixes an issue related to class reloading in Rails development and test modes
+
 0.11.2
 -----------
 Safely handle bad UTF-8 encoded strings passed in as event arguments

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    reactor (0.11.2)
+    reactor (0.11.4)
       activerecord (< 5.0)
       sidekiq
 
@@ -45,7 +45,7 @@ GEM
       rspec-core (~> 3.4.0)
       rspec-expectations (~> 3.4.0)
       rspec-mocks (~> 3.4.0)
-    rspec-core (3.4.2)
+    rspec-core (3.4.4)
       rspec-support (~> 3.4.0)
     rspec-expectations (3.4.0)
       diff-lcs (>= 1.2.0, < 2.0)

--- a/lib/reactor/models/concerns/subscribable.rb
+++ b/lib/reactor/models/concerns/subscribable.rb
@@ -4,18 +4,25 @@ module Reactor::Subscribable
   class EventHandlerAlreadyDefined < StandardError ; end
 
   module ClassMethods
+
     def on_event(*args, &block)
       options = args.extract_options!
       event, method = args
-      (Reactor::SUBSCRIBERS[event.to_s] ||= []).push(create_static_subscriber(event, method, options, &block))
+      if subscriber = create_static_subscriber(event, method, options, &block)
+        (Reactor::SUBSCRIBERS[event.to_s] ||= []).push(subscriber)
+      end
     end
 
     private
 
     def create_static_subscriber(event, method = nil, options = {}, &block)
       worker_class = build_worker_class
+      handler_name = handler_name(event, options[:handler_name])
+      check_for_duplicate_handler_name(handler_name)
 
-      name_worker_class worker_class, handler_name(event, options[:handler_name])
+      # return if the handler has already been defined (in the case of the class being reloaded)
+      return if static_subscriber_namespace.const_defined?(handler_name)
+      name_worker_class worker_class, handler_name
 
       worker_class.tap do |k|
         k.source = self
@@ -29,6 +36,10 @@ module Reactor::Subscribable
     def handler_name(event, handler_name_option = nil)
       return handler_name_option.to_s.camelize if handler_name_option
       "#{event == '*' ? 'Wildcard': event.to_s.camelize}Handler"
+    end
+
+    def event_handler_names
+      @event_handler_names ||= []
     end
 
     def build_worker_class
@@ -57,13 +68,17 @@ module Reactor::Subscribable
       end
     end
 
-    def name_worker_class(klass, handler_name)
-      if static_subscriber_namespace.const_defined?(handler_name)
+    def check_for_duplicate_handler_name(handler_name)
+      if event_handler_names.include?(handler_name)
         raise EventHandlerAlreadyDefined.new(
           "A Reactor event named #{handler_name} already has been defined on #{static_subscriber_namespace}.
            Specify a `:handler_name` option on your subscriber's `on_event` declaration to name this event handler deterministically."
         )
       end
+      event_handler_names << handler_name
+    end
+
+    def name_worker_class(klass, handler_name)
       static_subscriber_namespace.const_set(handler_name, klass)
     end
 

--- a/lib/reactor/version.rb
+++ b/lib/reactor/version.rb
@@ -1,3 +1,3 @@
 module Reactor
-  VERSION = "0.11.2"
+  VERSION = "0.11.4"
 end


### PR DESCRIPTION
this is to get around the class reloading issue in development/test mode
bot review me @davidrunger 