### PR TITLE
Correctly handles exceptions in with_subscriber_enabled

### DIFF
--- a/lib/reactor.rb
+++ b/lib/reactor.rb
@@ -42,6 +42,7 @@ module Reactor
   def self.with_subscriber_enabled(klass)
     enable_test_mode_subscriber klass
     yield if block_given?
+  ensure
     disable_test_mode_subscriber klass
   end
 end

--- a/spec/reactor_spec.rb
+++ b/spec/reactor_spec.rb
@@ -34,6 +34,24 @@ describe Reactor do
           Reactor::Event.publish :test_event
         end
       end
+
+      it 'disables the subscriber outside the block' do
+        expect(Reactor::TEST_MODE_SUBSCRIBERS).to be_empty
+        Reactor.with_subscriber_enabled(subscriber) do
+          expect(Reactor::TEST_MODE_SUBSCRIBERS).to contain_exactly(subscriber)
+        end
+        expect(Reactor::TEST_MODE_SUBSCRIBERS).to be_empty
+      end
+
+      it 'correctly handles exceptions inside the block' do
+        expect(Reactor::TEST_MODE_SUBSCRIBERS).to be_empty
+        expect {
+          Reactor.with_subscriber_enabled(subscriber) do
+            raise RuntimeError
+          end
+        }.to raise_error(RuntimeError)
+        expect(Reactor::TEST_MODE_SUBSCRIBERS).to be_empty
+      end
     end
   end
 end


### PR DESCRIPTION
If an exception is raised inside a with_subscriber_enabled block, the
temporarily enabled subscriber was not being correctly removed from the
TEST_MODE_SUBSCRIBERS set, potentially poisoning other tests.