### PR TITLE
Remove Sidekiq delayed extensions

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,5 +1,9 @@
 # Reactor Change Log
 
+0.14.0
+-----------
+Remove any use of `Sidekiq::Delayed` extensions. mperham [specifically discourages their use](https://github.com/mperham/sidekiq/wiki/Delayed-extensions), and they do not work in Rails 5 development mode. They serialize & deserialize the monkey-patched objects as `!ruby/object:` , which is [possible in YAML](http://yaml.org/YAML_for_ruby.html#objects), but causes all kinds of problems in a real application.
+
 0.12.2
 -----------
 Correctly handles exceptions in `with_subscriber_enabled`
@@ -12,7 +16,7 @@ Fix unicode encoding protection to allow valid multi-byte unicode characters
 -----------
 Use `__data__` as the internal data hash. THIS _MAY BE_ A BREAKING CHANGE.
 
-If someone wants to use the key `data` for their event attributes, it would get confused with the internal event data. The internal event data is now called `__data__`. 
+If someone wants to use the key `data` for their event attributes, it would get confused with the internal event data. The internal event data is now called `__data__`.
 Some users of this library access event.data directly. This is a breaking change for them.
 
 0.11.4

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    reactor (0.13.0)
+    reactor (0.14.0)
       activerecord (~> 5.0.1)
       sidekiq
 
@@ -39,7 +39,7 @@ GEM
     rack-protection (1.5.3)
       rack
     rake (12.0.0)
-    redis (3.3.2)
+    redis (3.3.3)
     rspec (3.5.0)
       rspec-core (~> 3.5.0)
       rspec-expectations (~> 3.5.0)
@@ -56,7 +56,7 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.5.0)
     rspec-support (3.5.0)
-    sidekiq (4.2.9)
+    sidekiq (4.2.10)
       concurrent-ruby (~> 1.0)
       connection_pool (~> 2.2, >= 2.2.0)
       rack-protection (>= 1.5.0)
@@ -84,4 +84,4 @@ DEPENDENCIES
   test_after_commit
 
 BUNDLED WITH
-   1.13.6
+   1.14.6

--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ Once you write your own action_event to describe your event data model's base at
 <dt>index =></dt>
 <dd>"pets_indexed"</dd>
 </dl>
- 
+
 <dl>
 <dt>show =></dt>
 <dd>"pet_viewed", target: @pet</dd>
@@ -167,7 +167,7 @@ Once you write your own action_event to describe your event data model's base at
 
 <dl>
 <dt>update =></dt>
-<dd> 
+<dd>
 when valid => "pet_updated", target: @pet, changes: @pet.previous_changes.as_json
 <br />
   when invalid => "pet_update_failed", target: @pet,
@@ -183,7 +183,7 @@ when valid => "pet_updated", target: @pet, changes: @pet.previous_changes.as_jso
 
 ##### What for?
 
-If you're obsessive about data like us, you'll have written a '*' subscriber that logs every event fired in the system. With information-dense resource information logged for each action a user performs, it will be trivial for a data analyst to determine patterns in user activity. For example, with the above data being logged for the pet resource, we can easily
+If you're obsessive about data like us, you'll have written a `'*'` subscriber that logs every event fired in the system. With information-dense resource information logged for each action a user performs, it will be trivial for a data analyst to determine patterns in user activity. For example, with the above data being logged for the pet resource, we can easily
 * determine which form field validations are constantly being hit by users
 * see if there are any fields that are consistently ignored on that form until later
 * recover data from the last_snapshot of a destroyed record
@@ -218,14 +218,21 @@ end
 
 ### Testing
 
-Calling `Reactor.test_mode!` enables test mode.  (You should call this as early as possible, before your subscriber classes
-are declared).  In test mode, no subscribers will fire unless they are specifically enabled, which can be accomplished
-by calling
+Calling `Reactor.test_mode!` enables test mode. You should call this as early as possible, before your subscriber classes are declared.
+
+```ruby
+# config/initializers/reactor.rb
+Reactor.test_mode! if Rails.env.test?
+```
+
+In test mode, no subscribers will fire unless they are specifically enabled, which can be accomplished by calling
+
 ```ruby
 Reactor.enable_test_mode_subscriber(MyAwesomeSubscriberClass)
 ```
 
 We also provide
+
 ```ruby
 Reactor.with_subscriber_enabled(MyClass) do
   # stuff

--- a/lib/reactor/event.rb
+++ b/lib/reactor/event.rb
@@ -118,7 +118,7 @@ class Reactor::Event
   def fire_database_driven_subscribers(data, name)
     #TODO: support more matching?
     Reactor::Subscriber.where(event_name: [name, '*']).each do |subscriber|
-      Reactor::Subscriber.delay.fire subscriber.id, data
+      Reactor::Subscriber.fire_async subscriber.id, data
     end
   end
 

--- a/lib/reactor/models/subscriber.rb
+++ b/lib/reactor/models/subscriber.rb
@@ -22,5 +22,17 @@ class Reactor::Subscriber < ActiveRecord::Base
     def fire(subscriber_id, data)
       Reactor::Subscriber.find(subscriber_id).fire data
     end
+
+    def fire_async(subscriber_id, data)
+      SubscriberWorker.perform_async(subscriber_id, data)
+    end
+  end
+
+  class SubscriberWorker
+    include Sidekiq::Worker
+
+    def perform(subscriber_id, data)
+      Reactor::Subscriber.find(subscriber_id).fire data.with_indifferent_access
+    end
   end
 end

--- a/lib/reactor/version.rb
+++ b/lib/reactor/version.rb
@@ -1,3 +1,3 @@
 module Reactor
-  VERSION = "0.13.0"
+  VERSION = "0.14.0"
 end

--- a/reactor.gemspec
+++ b/reactor.gemspec
@@ -8,8 +8,8 @@ Gem::Specification.new do |spec|
   spec.version       = Reactor::VERSION
   spec.authors       = ["winfred", "walt", "nate", "petermin"]
   spec.email         = ["winfred@hired.com", "walt@hired.com", "nate@hired.com", "kengteh.min@gmail.com"]
-  spec.description   = %q{ rails chrono reactor }
-  spec.summary       = %q{ Sidekiq/ActiveRecord pubsub lib }
+  spec.description   = %q{ Sidekiq pub/sub interface }
+  spec.summary       = %q{ Sidekiq pub/sub lib, allowing it to act as a global message bus. Extensions for Rails included. }
   spec.homepage      = ""
   spec.license       = "MIT"
 

--- a/spec/models/concerns/publishable_spec.rb
+++ b/spec/models/concerns/publishable_spec.rb
@@ -88,6 +88,8 @@ describe Reactor::Publishable do
     end
 
     context 'conditional firing' do
+      let(:subscriber_worker) { Reactor::Subscriber::SubscriberWorker }
+
       before do
         Sidekiq::Testing.fake!
         Sidekiq::Worker.clear_all
@@ -108,7 +110,9 @@ describe Reactor::Publishable do
         auction.start_at = 3.day.from_now
         auction.save!
 
-        expect{ Reactor::Event.perform(@job_args[0], @job_args[1]) }.to change{ Sidekiq::Extensions::DelayedClass.jobs.size }
+        expect{ Reactor::Event.perform(@job_args[0], @job_args[1]) }.to change {
+          subscriber_worker.jobs.count
+        }.by(1)
       end
 
       it 'does not call the subscriber when if is set to false' do

--- a/spec/models/concerns/subscribable_spec.rb
+++ b/spec/models/concerns/subscribable_spec.rb
@@ -63,6 +63,8 @@ describe Reactor::Subscribable do
     end
 
     describe 'binding symbol of class method' do
+      let(:puppy_handler) { Reactor::StaticSubscribers::Auction::PoopedHandler }
+
       it 'fires on event' do
         expect(Auction).to receive(:ring_bell)
         Reactor::Event.publish(:puppy_delivered)
@@ -70,7 +72,9 @@ describe Reactor::Subscribable do
 
       it 'can be delayed' do
         expect(Auction).to receive(:pick_up_poop)
-        expect(Auction).to receive(:delay_for).with(5.minutes).and_return(Auction)
+        expect(puppy_handler).to receive(:perform_in).with(
+          5.minutes, anything, skip_delay: true
+        ).and_call_original
         Reactor::Event.perform('pooped', {})
       end
     end


### PR DESCRIPTION
Remove any use of `Sidekiq::Delayed` extensions. mperham [specifically discourages their use](https://github.com/mperham/sidekiq/wiki/Delayed-extensions), and they do not work in Rails 5 development mode. They serialize & deserialize the monkey-patched objects as `!ruby/object:` , which is [possible in YAML](http://yaml.org/YAML_for_ruby.html#objects), but causes all kinds of problems in a real application.

This adds some logic to the ActiveRecord subscribable `.perform` method, and adds a generic worker for `Reactor::Subscriber` . May not be the best solution, but we're due for an architecture review anyhow.

/cc @joelmichael @wnadeau @heythisisnate 