### PR TITLE
Fix constant definition warnings

### DIFF
--- a/lib/reactor/subscription.rb
+++ b/lib/reactor/subscription.rb
@@ -29,7 +29,7 @@ module Reactor
 
     def handler_defined?
       namespace.const_defined?(handler_name) &&
-        namespace.const_get(handler_name).ancestors.include?(Reactor.subscriber_namespace)
+        namespace.const_get(handler_name).parents.include?(Reactor.subscriber_namespace)
     end
 
     def event_handler_names
@@ -68,8 +68,7 @@ module Reactor
     end
 
     def build_worker_class
-      return @worker_class = namespace.const_get(handler_name) if handler_defined?
-
+      namespace.send(:remove_const, handler_name) if handler_defined?
 
       worker_class = mailer_subscriber? ? build_mailer_worker : build_event_worker
       namespace.const_set(handler_name, worker_class)

--- a/lib/reactor/version.rb
+++ b/lib/reactor/version.rb
@@ -1,3 +1,3 @@
 module Reactor
-  VERSION = "0.14.0"
+  VERSION = "0.15.0"
 end


### PR DESCRIPTION
They were caused by re-loading subscribers while using Spring.
The "ancestors" logic here was wrong; it has to be "parents" instead.
Also, remove and re-set the constant instead of returning the old constant, because its value may have changed.
Done with @agius.