### PR TITLE
publishable/subscribable opt-in instead of default mixed into AR::Base

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,8 @@ Or install it yourself as:
 
 ## Usage
 
-Well, this is evolving, so it's probably best to go read the specs.
+Well, this is evolving, so it's probably best to go read the specs as
+well as below.
 
 
 ### Barebones API
@@ -38,6 +39,29 @@ Reactor::Event.publish(:event_name, any: 'data', you: 'want')
 ```
 
 ### ActiveModel extensions
+
+```
+class ApplicationRecord < ActiveRecord::Base
+  self.abstract_class = true
+
+  include Reactor::Subscribable
+  include Reactor::Publishable
+end
+```
+
+or if you want to encourage a specific data model, ex: encourage Users to be actors.
+
+```
+class ApplicationRecord < ActiveRecord::Base
+  self.abstract_class = true
+
+  include Reactor::Subscribable
+end
+
+class User < ApplicationRecord
+  include Reactor::Publishable
+end
+```
 
 #### Publishable
 

--- a/README.md
+++ b/README.md
@@ -38,30 +38,6 @@ well as below.
 Reactor::Event.publish(:event_name, any: 'data', you: 'want')
 ```
 
-### ActiveModel extensions
-
-```
-class ApplicationRecord < ActiveRecord::Base
-  self.abstract_class = true
-
-  include Reactor::Subscribable
-  include Reactor::Publishable
-end
-```
-
-or if you want to encourage a specific data model, ex: encourage Users to be actors.
-
-```
-class ApplicationRecord < ActiveRecord::Base
-  self.abstract_class = true
-
-  include Reactor::Subscribable
-end
-
-class User < ApplicationRecord
-  include Reactor::Publishable
-end
-```
 
 #### Publishable
 

--- a/lib/reactor.rb
+++ b/lib/reactor.rb
@@ -37,6 +37,3 @@ module Reactor
     Reactor::StaticSubscribers
   end
 end
-
-ActiveRecord::Base.send(:include, Reactor::Publishable)
-ActiveRecord::Base.send(:include, Reactor::Subscribable)

--- a/spec/event_spec.rb
+++ b/spec/event_spec.rb
@@ -8,7 +8,7 @@ module MyModule
   end
 end
 
-class ArbitraryModel < ActiveRecord::Base
+class ArbitraryModel < ApplicationRecord
 
   on_event :barfed, handler_name: :bad do
     raise 'UNEXPECTED!'

--- a/spec/models/concerns/publishable_spec.rb
+++ b/spec/models/concerns/publishable_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 require 'sidekiq/testing'
 
-class Publisher < ActiveRecord::Base
+class Publisher < ApplicationRecord
   belongs_to :pet
 
   def ring_timeout

--- a/spec/models/concerns/subscribable_spec.rb
+++ b/spec/models/concerns/subscribable_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-class Auction < ActiveRecord::Base
+class Auction < ApplicationRecord
   on_event :bid_made do |event|
     event.target.update_column :status, 'first_bid_made'
   end
@@ -68,7 +68,7 @@ class KittenMailer < ActionMailer::Base
 end
 
 Reactor.in_test_mode do
-  class TestModeAuction < ActiveRecord::Base
+  class TestModeAuction < ApplicationRecord
     on_event :test_puppy_delivered, -> (event) { "success" }
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -18,6 +18,18 @@ require 'reactor/testing/matchers'
 
 require 'rspec/its'
 
+class ApplicationRecord < ActiveRecord::Base
+  self.abstract_class = true
+  include Reactor::Publishable
+  include Reactor::Subscribable
+end
+
+class Pet < ApplicationRecord
+end
+
+class ArbitraryModel < ApplicationRecord
+end
+
 REDIS_URL = ENV["REDISTOGO_URL"] || ENV["REDIS_URL"] || "redis://localhost:6379/4"
 
 ActionMailer::Base.delivery_method = :test

--- a/spec/support/active_record.rb
+++ b/spec/support/active_record.rb
@@ -38,8 +38,3 @@ ActiveRecord::Migration.create_table :arbitrary_models do |t|
   t.timestamps null: false
 end
 
-class Pet < ActiveRecord::Base
-end
-
-class ArbitraryModel < ActiveRecord::Base
-end


### PR DESCRIPTION
1. it lets applications guide usage more discretely,
  such as when only mixing into a `User` so the code
  encourages team members to follow a specific event data model
  (ex- when you want to encourage others to have only a user actor on the event, not unlike the segment.com event model, >90% of the time is the case)

2. especially because its easy-to-do app-side, even encouraged 
  with the new Rails 5 `ApplicationRecord` pattern default, 
  this kind of hefty decision just shouldn't be a responsibility of Reactor