### PR TITLE
remove unused, useless async/in_memory feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,15 +87,7 @@ on_event :any_event do |event|
 end
 ```
 
-  Static subscribers like these are automatically placed into Sidekiq and executed in the background
-
-  It's also possible to run a subscriber block in memory like so
-
-```ruby
-on_event :any_event, in_memory: true do |event|
-  event.target.do_something_about_it_and_make_the_user_wait!
-end
-```
+  Static subscribers like these are automatically placed into Sidekiq and executed in the background.
 
   You may also have Sidekiq process a subscriber block on a specific queue or supply any other Sidekiq::Worker options accordingly.
 

--- a/lib/reactor/workers/concerns/configuration.rb
+++ b/lib/reactor/workers/concerns/configuration.rb
@@ -3,7 +3,7 @@ module Reactor
     module Configuration
       extend ActiveSupport::Concern
 
-      CONFIG = [:source, :action, :async, :delay, :deprecated]
+      CONFIG = [:source, :action, :delay, :deprecated]
 
       included do
         include Sidekiq::Worker
@@ -21,10 +21,8 @@ module Reactor
             return
           elsif delay > 0
             event_queue.perform_in(delay, data)
-          elsif async
-            event_queue.perform_async(data)
           else
-            new.perform(data)
+            event_queue.perform_async(data)
           end
           source
         end

--- a/spec/support/shared_examples.rb
+++ b/spec/support/shared_examples.rb
@@ -24,22 +24,12 @@ shared_examples_for 'configurable subscriber worker' do
       end
     end
 
-    context 'for async workers' do
+    context 'for not delayed workers' do
       let(:klass) { MyEventWorker }
       subject { klass.perform_where_needed(event_data) }
 
       it 'uses perform_async to execute wherever' do
         expect(klass).to receive(:perform_async).with(event_data)
-        subject
-      end
-    end
-
-    context 'for immediate workers' do
-      let(:klass) { MyImmediateWorker }
-      subject { klass.perform_where_needed(event_data) }
-
-      it 'creates and executes new instance' do
-        expect_any_instance_of(klass).to receive(:perform).with(event_data)
         subject
       end
     end

--- a/spec/workers/event_worker_spec.rb
+++ b/spec/workers/event_worker_spec.rb
@@ -14,7 +14,6 @@ end
 class MyEventWorker < Reactor::Workers::EventWorker
   self.source = SourceSubscriber
   self.action = :fire_worker
-  self.async  = true
   self.delay  = 0
   self.deprecated = false
 end
@@ -22,7 +21,6 @@ end
 class MyBlockWorker < Reactor::Workers::EventWorker
   self.source = SourceSubscriber
   self.action = lambda { |event| :block_ran }
-  self.async  = true
   self.delay  = 0
   self.deprecated = false
 end
@@ -30,16 +28,7 @@ end
 class MyDelayedWorker < Reactor::Workers::EventWorker
   self.source = SourceSubscriber
   self.action = :fire_worker
-  self.async  = true
   self.delay  = 1 # seconds
-  self.deprecated = false
-end
-
-class MyImmediateWorker < Reactor::Workers::EventWorker
-  self.source = SourceSubscriber
-  self.action = :fire_worker
-  self.async  = false
-  self.delay  = 0
   self.deprecated = false
 end
 

--- a/spec/workers/mailer_worker_spec.rb
+++ b/spec/workers/mailer_worker_spec.rb
@@ -14,14 +14,12 @@ end
 class MyMailerWorker < Reactor::Workers::MailerWorker
   self.source = MailerSubscriber
   self.action = :fire_mailer
-  self.async  = false
   self.delay  = 0
   self.deprecated = false
 end
 
 class MyBlockMailerWorker < Reactor::Workers::MailerWorker
   self.source = MailerSubscriber
-  self.async  = false
   self.delay  = 0
   self.action = lambda { |event| fire_mailer(event) }
   self.deprecated = false


### PR DESCRIPTION
see #70 for more about why this doesnt fit the project philosophy
and empirically it wasn't used anywhere either.

two strikes, you're out