### PR TITLE
let ENV var override which queue publish & subscribers are worked on

### DIFF
--- a/lib/reactor/event.rb
+++ b/lib/reactor/event.rb
@@ -1,6 +1,8 @@
 class Reactor::Event
   include Sidekiq::Worker
 
+  sidekiq_options queue: ENV['REACTOR_QUEUE'] || Sidekiq.default_worker_options['queue']
+
   CONSOLE_CONFIRMATION_MESSAGE = <<-eos
     It looks like you are on a production console. Only fire an event if you intend to trigger 
     all of its subscribers. In order to proceed, you must pass `srsly: true` in the event data.'

--- a/lib/reactor/version.rb
+++ b/lib/reactor/version.rb
@@ -1,3 +1,3 @@
 module Reactor
-  VERSION = "0.18.0"
+  VERSION = "0.19.0"
 end

--- a/lib/reactor/workers/concerns/configuration.rb
+++ b/lib/reactor/workers/concerns/configuration.rb
@@ -20,13 +20,18 @@ module Reactor
           if deprecated
             return
           elsif delay > 0
-            perform_in(delay, data)
+            event_queue.perform_in(delay, data)
           elsif async
-            perform_async(data)
+            event_queue.perform_async(data)
           else
             new.perform(data)
           end
           source
+        end
+
+        def event_queue
+          queue_override = ENV['REACTOR_QUEUE']
+          queue_override.present? ? set(queue: queue_override) : self
         end
       end
 

--- a/spec/models/concerns/subscribable_spec.rb
+++ b/spec/models/concerns/subscribable_spec.rb
@@ -166,6 +166,21 @@ describe Reactor::Subscribable do
       end
     end
 
+    describe 'overriding queue options with ENV variable to isolate cascade between processes' do
+      before { ENV['REACTOR_QUEUE'] = 'bulk' }
+      after { ENV.delete('REACTOR_QUEUE') }
+
+      specify do
+        expect_any_instance_of(Reactor::StaticSubscribers::Auction::WildcardHandler).
+            to receive(:perform)
+
+        expect(Reactor::StaticSubscribers::Auction::WildcardHandler).to receive(:set).
+            with(hash_including(queue: 'bulk')).and_call_original
+
+        Reactor::Event.publish(:puppy_delivered)
+      end
+    end
+
     describe '#perform' do
       around(:each) do |example|
         Reactor.in_test_mode { example.run }


### PR DESCRIPTION
say we have a `bulk` worker and a standard/realtime, expected-to-be-moving-quickly `worker` worker in our procfile.

```
web: rails s
worker: bundle exec sidekiq -c ${SIDEKIQ_CONCURRENCY:-25} -C config/sidekiq.yml
bulk: REACTOR_QUEUE=bulk_reactor bundle exec sidekiq -c ${SIDEKIQ_CONCURRENCY:-25} -C config/bulk.yml
```

Well now any events triggered in `bulk` will get picked up by `bulk` and leave `worker` unfazed. (Thus isolating jobs with realtime-esque expectations from bulkier jobs known for crunching a lot of data.)
