### PR TITLE
Allow disabling a subscriber in a block

### DIFF
--- a/lib/reactor/testing.rb
+++ b/lib/reactor/testing.rb
@@ -40,6 +40,13 @@ module Reactor
     disable_test_mode_subscriber klass
   end
 
+  def with_subscriber_disabled(klass)
+    disable_test_mode_subscriber klass
+    yield if block_given?
+  ensure
+    enable_test_mode_subscriber klass
+  end
+
   def clear_test_subscribers!
     test_mode_subscribers.each {|klass| test_mode_subscribers.delete klass }
   end

--- a/spec/reactor_spec.rb
+++ b/spec/reactor_spec.rb
@@ -55,5 +55,34 @@ describe Reactor do
         expect(Reactor::TEST_MODE_SUBSCRIBERS).to be_empty
       end
     end
+
+    describe '.with_subscriber_disabled' do
+      before { Reactor.enable_test_mode_subscriber(subscriber) }
+
+      it 'disables a subscriber during test mode' do
+        expect(subscriber).not_to receive :spy_on_me
+        Reactor.with_subscriber_disabled(subscriber) do
+          Reactor::Event.publish :test_event
+        end
+      end
+
+      it 'enables the subscriber outside the block' do
+        expect(Reactor::TEST_MODE_SUBSCRIBERS).to contain_exactly(subscriber)
+        Reactor.with_subscriber_disabled(subscriber) do
+          expect(Reactor::TEST_MODE_SUBSCRIBERS).to be_empty
+        end
+        expect(Reactor::TEST_MODE_SUBSCRIBERS).to contain_exactly(subscriber)
+      end
+
+      it 'correctly handles exceptions inside the block' do
+        expect(Reactor::TEST_MODE_SUBSCRIBERS).to contain_exactly(subscriber)
+        expect {
+          Reactor.with_subscriber_disabled(subscriber) do
+            raise RuntimeError
+          end
+        }.to raise_error(RuntimeError)
+        expect(Reactor::TEST_MODE_SUBSCRIBERS).to contain_exactly(subscriber)
+      end
+    end
   end
 end


### PR DESCRIPTION
I've used this to temporarily disable a subscriber, for example when
testing a subscriber that listens for an event fired by creating a
`User`, but I want to test what happens when a `User` already exists:

```ruby
Reactor.disable_test_mode_subscriber { create(:user) }
create(:user)
```