### PR TITLE
temporarily disable subscriber in a test

### DIFF
--- a/lib/reactor/testing/stubs.rb
+++ b/lib/reactor/testing/stubs.rb
@@ -25,3 +25,25 @@ def allow_reactor_subscriber(subscribable_class)
 
   yield if block_given? # yes you can use block syntax if you want
 end
+
+#
+# If you publish events in ActiveRecord lifecycle hooks, you're gonna have a bad time.
+#
+# But inevitably it may make sense for you (yay software), in which case you may want to
+#  disable a subscriber if you're testing logic around it.
+#
+def disable_reactor_subscriber(subscribable_class)
+  worker_module = "Reactor::StaticSubscribers::#{subscribable_class}".safe_constantize
+  worker_module.constants.each do |worker_class_name|
+
+    worker_class = "Reactor::StaticSubscribers::#{subscribable_class}::#{worker_class_name}".
+        safe_constantize
+
+    allow(worker_class).to receive(:perform_where_needed).and_return(nil)
+  end
+
+  if block_given? # yes you can use block syntax if you want
+    yield
+    allow_reactor_subscriber(subscribable_class) # and if you do, expect it to be re-enabled after
+  end
+end


### PR DESCRIPTION
following up with #75 - but in the 1.0 test mode paradigm

it may be a code smell, but it seems we need this to get the hired/hired reactor 1.0 branch passing.

the 'disable' concept is used non-trivially in one file in hired/hired, and I don't feel like I've seen enough of this pokemon in the wild to say for sure 'we should' or 'we shouldnt'... so might as well let it bake, eh?