### PR TITLE
let users supply a block to validate their events against a schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,24 @@ TLDR; Everything is a Sidekiq::Worker, so all the same gotchas apply with regard
 
 This is as easy as write + deploy. Of course your events getting fired won't have a subscriber pick them up until the new subscriber code is deployed in your sidekiq instances, but that's not too surprising.
 
+#### Validating Events On Publish
+
+As of 1.0 you may inject your own validator lambda to handle the logic and flow-control of valid/invalid events.
+
+This is entirely optional and the default behavior is to do nothing, to not validate any data being provided.
+
+```ruby
+# in config/initializers/reactor.rb
+Reactor.validator -> do |event|
+  Activity.build_from_event(event).validate! # you own the performance implications here
+end
+```
+
+We at Hired use this to validate the event's schema as we found having stricter schema definitions 
+gave us more leverage as our team grew.
+
+By injecting your own logic, you can be as permissive or strict as you want. (Throw exceptions if you want, even.)
+
 #### Removing Events and Subscribers
 
 Removing an event is as simple as deleting the line of code that `publish`es it.

--- a/lib/reactor.rb
+++ b/lib/reactor.rb
@@ -13,6 +13,7 @@ require "reactor/event"
 
 module Reactor
   SUBSCRIBERS = {}.with_indifferent_access
+  BASE_VALIDATOR = -> (_event) { } # default behavior is to not actually validate anything
 
   module_function
 
@@ -31,5 +32,18 @@ module Reactor
 
   def subscriber_namespace
     Reactor::StaticSubscribers
+  end
+
+  #
+  # If you want, you can inject your own validator block in `config/initializers/reactor.rb`
+  #
+  # Reactor.validator -> (event) { Validator.new(event).validate! }
+  #
+  # If not, the default behavior is to do nothing. (see Reactor::BASE_VALIDATOR)
+  #
+  def validator(block = nil)
+    @validator = block if block.present?
+
+    @validator || BASE_VALIDATOR
   end
 end

--- a/lib/reactor/event.rb
+++ b/lib/reactor/event.rb
@@ -66,6 +66,8 @@ class Reactor::Event
 
       message = new(data.merge(event: name, uuid: SecureRandom.uuid))
 
+      Reactor.validator.call(message)
+
       if message.at
         perform_at message.at, name, message.__data__
       else

--- a/spec/event_spec.rb
+++ b/spec/event_spec.rb
@@ -78,6 +78,17 @@ describe Reactor::Event do
         ENV['RACK_ENV'] = 'development'
       end
     end
+
+    describe 'using injected validator block' do
+      before { Reactor.validator -> (_event) {raise 'InvalidEvent'} }
+      after { Reactor.validator Reactor::BASE_VALIDATOR }
+
+      it 'gets called and yields flow control' do
+        expect {
+          Reactor::Event.publish(:something)
+        }.to raise_error(RuntimeError, 'InvalidEvent')
+      end
+    end
   end
 
   describe 'perform' do


### PR DESCRIPTION
They can decide how that is done and if they want to throw an exception.

We are looking at embracing wnadeau/descendants_describable and building a DSL
for declaratively describing our data model and event schemas.

It could look something like this

```
# in config/initializers/reactor.rb
Reactor.validator -> (event) do
  Activity.build_with_reactor_event(event).validate_schema!
end
```

### This is all very exploratory at the moment.