### PR TITLE
add disable_reactor_subscriber(MySub) to support/testing/stubs

### DIFF
--- a/lib/reactor/testing/stubs.rb
+++ b/lib/reactor/testing/stubs.rb
@@ -14,14 +14,33 @@ end
 # to test its logic.
 #
 def allow_reactor_subscriber(subscribable_class)
-  worker_module = "Reactor::StaticSubscribers::#{subscribable_class}".safe_constantize
-  worker_module.constants.each do |worker_class_name|
-
-    worker_class = "Reactor::StaticSubscribers::#{subscribable_class}::#{worker_class_name}".
-        safe_constantize
-
+  worker_module_name = "Reactor::StaticSubscribers::#{subscribable_class}"
+  worker_module_name.safe_constantize.constants.each do |worker_class_name|
+    worker_class = "#{worker_module_name}::#{worker_class_name}".safe_constantize
     allow(worker_class).to receive(:perform_where_needed).and_call_original
   end
 
   yield if block_given? # yes you can use block syntax if you want
+end
+
+#
+# If you publish events in ActiveRecord lifecycle hooks, you're gonna have a bad time.
+#
+# But inevitably it may make sense for you (yay software), in which case you may want to
+#  disable a subscriber if you're testing logic around it.
+#
+def disable_reactor_subscriber(subscribable_class)
+  worker_module_name = "Reactor::StaticSubscribers::#{subscribable_class}"
+  worker_module_name.safe_constantize.constants.each do |worker_class_name|
+    worker_class = "#{worker_module_name}::#{worker_class_name}".safe_constantize
+    allow(worker_class).to receive(:perform_where_needed).and_return(nil)
+  end
+
+  if block_given? # yes you can use block syntax if you want
+    begin
+      yield
+    ensure
+      allow_reactor_subscriber(subscribable_class) # and if you do, expect it to be re-enabled after
+    end
+  end
 end


### PR DESCRIPTION
see the comment, if you `after_create_commit -> { publish :thing_created }`
you will probably need this at some point.

also you may want to consider not publishing events in lifecycle hooks
but I havent seen enough examples to have a strong opinion on it
just noting the risks and providing some tools to help us
keep exploring. :)