### PR TITLE
Use #fetch to limit time range we scan

### DIFF
--- a/lib/reactor/event.rb
+++ b/lib/reactor/event.rb
@@ -77,19 +77,20 @@ class Reactor::Event
 
     def reschedule(name, data = {})
       scheduled_jobs = Sidekiq::ScheduledSet.new
+      # Note that scheduled_jobs#fetch returns only jobs matching the data[:was]
+      # timestamp - down to fractions of a second
       job = scheduled_jobs.fetch(data[:was].to_f).detect do |job|
         next if job['class'] != self.name.to_s
 
         same_event_name  = job['args'].first == name.to_s
-        same_at_time     = job.score.to_i == data[:was].to_i
 
         if data[:actor]
           same_actor =  job['args'].second['actor_type']  == data[:actor].class.name &&
                         job['args'].second['actor_id']    == data[:actor].id
 
-          same_event_name && same_at_time && same_actor
+          same_event_name && same_actor
         else
-          same_event_name && same_at_time
+          same_event_name
         end
       end
 

--- a/lib/reactor/event.rb
+++ b/lib/reactor/event.rb
@@ -77,7 +77,7 @@ class Reactor::Event
 
     def reschedule(name, data = {})
       scheduled_jobs = Sidekiq::ScheduledSet.new
-      job = scheduled_jobs.detect do |job|
+      job = scheduled_jobs.fetch(data[:was].to_f).detect do |job|
         next if job['class'] != self.name.to_s
 
         same_event_name  = job['args'].first == name.to_s


### PR DESCRIPTION
Sidekiq::Api allows ScheduledSet to be fetched at a specific score (in case of scheduled set, this score is a timestamp), returning only jobs scheduled at that time.

This gives us O(log(n) + m) performance (n is number of items in list, and m is the count of items matching timestamp) instead of O((log(n)+m) * p) - (where p is pages). 

Since the each block pages through entries 50 at a time, the additional factor of "page number" - doing the same operation over multiple pages - becomes on the order of n, and m = 50 is a constant, so my fuzzy big-O understanding is it becomes an O(n * log(n)) operation. 

This turns out to be exactly what we might need to avoid the highly variable performance in issue #82 without any of the complications of the self-destruct method I was proposing in my comments there.  

Fixes #82. (potentially)

The each function being previously used: https://github.com/mperham/sidekiq/blob/master/lib/sidekiq/api.rb#L561-L580

The fetch function that we use to jump to the exact page of data we need instead:
https://github.com/mperham/sidekiq/blob/master/lib/sidekiq/api.rb#L582-L596